### PR TITLE
bump required tidyhydat version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     purrr (>= 0.3.2),
     RcppRoll (>= 0.3.0),
     scales (>= 1.0.0),
-    tidyhydat (>= 0.4.0),
+    tidyhydat (>= 0.5.6),
     tidyr (>= 0.8.3),
     zyp (>= 0.10.1.1)
 Suggests: 


### PR DESCRIPTION
Because of some ECCC changes, I had to change how HYDAT was named on disk. As a result previous versions of tidyhydat won't work moving forward, at least without some manual fixing. So this change will just force users to the right tidyhydat version. 