### PR TITLE
Try using setup-r-dependencies@v2 ?

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,7 +39,7 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
 


### PR DESCRIPTION
With the GitHub actions problem it looks very much like an *actions* problem, not a problem with your package (it's the setup step of installing dependencies that fails, so it doesn't even start testing your package). I've looked on rOpenSci slack but no one else has mentioned this issue so it might be a bit specific. 

I think there are a couple of things you can try:
1) Ignore the problem and wait and see if it fixes itself :grin:
2) Ignore the problem and submit to CRAN anyway (if that's what you're doing). If you're submitting to CRAN, this isn't evidence that your package fails, only that you can't check on R devel and Ubuntu. (~~Try R hub for an alternative; `devtools::check_rhub()`~~. Ah your tests on R hub are for a different problem, it too is having difficulties installing dependencies, perhaps because it's a relatively new version of R?)
3) Try updating to using the [v2 of setup-r-dependency](https://github.com/r-lib/actions/tree/v2/setup-r-dependencies) actions (this pull request). This pull request should hopefully run the checks and see if that works, if so, merge! If not, delete and try the above two options?
